### PR TITLE
[BUGFIX] Fix typo3/cms-core dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "license": "GPL-2.0+",
   "require": {
     "php": ">=5.6",
-    "typo3/cms-core": ">=7.6.0,>=8.7.0"
+    "typo3/cms-core": ">=7.6.0,<=8.7.99"
   },
   "require-dev": {
   },


### PR DESCRIPTION
This fixes the composer error where no matching typo3/cms-core version was found when trying to install typo3-varnish on TYPO3 7.6 due to wrong version syntax. The previous syntax was not met in any case.